### PR TITLE
Small compatibility fix with pymol 1.8.4.0

### DIFF
--- a/plip/modules/pymolplip.py
+++ b/plip/modules/pymolplip.py
@@ -290,7 +290,7 @@ class PyMOLVisualizer:
 
         selections = cmd.get_names("selections")
         for selection in selections:
-            if len(cmd.get_model(selection).atom) == 0:
+            if cmd.count_atoms(selection) == 0:
                 cmd.delete(selection)
         cmd.deselect()
         cmd.delete('tmp*')


### PR DESCRIPTION
PLIP seems to work fine with pymol versions in v1.8.x branch up to 1.8.4.0. In this last version, it looks like something have changed, and now, a CmdException is raised when trying to call "cmd.get_model" on an empty selection. This breaks PLIP 1.3.2 visualization generation.

By applying this patch, "len(cmd.get_model(selection).atom)" is substituted by a "cmd.count_atoms(selection)", which seems to work fine and achieve the same that was intended with the other code.