### PR TITLE
Always log to STDERR

### DIFF
--- a/plip/modules/supplemental.py
+++ b/plip/modules/supplemental.py
@@ -495,7 +495,4 @@ def message(msg, indent=False, mtype='standard', caption=False):
         msg = colorlog('Info:  ' + msg, 'green')
     if indent:
         msg = '  ' + msg
-    if mtype in ['error', 'warning']:
-        sys.stderr.write(msg)
-    else:
-        sys.stdout.write(msg)
+    sys.stderr.write(msg)


### PR DESCRIPTION
Logging some messages to STDOUT is problematic when using `--stdout` or `-O` as the output and logging information become entangled

    plip -i 1vsn -xvO > output.xml

Now output.xml contains both the output and logs (except warning and errors which don't happen here). It would be much nicer to have the logging written to STDERR, even for debug and info messages.