### PR TITLE
Make PyMOL an optional dependency

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -37,7 +37,7 @@ Please refer to the webpages of the corresponding tools to get help for installa
 To install all dependencies for PLIP, either just install PyMOL and then use the `pip` installation routine or install all tools and clone from GitHub.
 The current version of PLIP depends on
 * OpenBabel >=2.3.2
-* PyMOL 1.7.x with Python bindings
+* PyMOL 1.7.x with Python bindings (optional, for visualization only)
 * Imagemagick >=6.9.x (optional)
 
 and should be executed with Python 2.7.x.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Newer commits from the stable and development branch may contains new but untest
 Previous to using PLIP, make sure you have the following tools and libraries installed:
 * Python 2.7.x
 * OpenBabel >=2.3.2
-* PyMOL 1.7.x with Python bindings
+* PyMOL 1.7.x with Python bindings (optional, for visualization only)
 * Imagemagick >=6.9.x (optional)
 
 ## Contributions

--- a/plip/modules/supplemental.py
+++ b/plip/modules/supplemental.py
@@ -27,8 +27,6 @@ import pybel
 from pybel import *
 from openbabel import *
 import numpy as np
-from pymol import cmd
-from pymol import finish_launching
 import itertools
 
 # Settings
@@ -221,9 +219,10 @@ def cmd_exists(c):
 
 def initialize_pymol(options):
     """Initializes PyMOL"""
+    import pymol
     # Pass standard arguments of function to prevent PyMOL from printing out PDB headers (workaround)
-    finish_launching(args=['pymol', options, '-K'])
-    cmd.reinitialize()
+    pymol.finish_launching(args=['pymol', options, '-K'])
+    pymol.cmd.reinitialize()
 
 
 def start_pymol(quiet=False, options='-p', run=False):
@@ -234,7 +233,7 @@ def start_pymol(quiet=False, options='-p', run=False):
     if run:
         initialize_pymol(options)
     if quiet:
-        cmd.feedback('disable', 'all', 'everything')
+        pymol.cmd.feedback('disable', 'all', 'everything')
 
 def nucleotide_linkage(residues):
     """Support for DNA/RNA ligands by finding missing covalent linkages to stitch DNA/RNA together."""

--- a/plip/plipcmd
+++ b/plip/plipcmd
@@ -253,6 +253,13 @@ if __name__ == '__main__':
     config.NOFIXFILE = arguments.nofixfile
     config.KEEPMOD = arguments.keepmod
     config.DNARECEPTOR = arguments.dnareceptor
+    # Make sure we have pymol with --pics and --pymol
+    if config.PICS or config.PYMOL:
+        try:
+            import pymol
+        except ImportError:
+            write_message("PyMOL is required for --pics and --pymol.\n", mtype='error')
+            raise
     # Assign values to global thresholds
     for t in thresholds:
         tvalue = getattr(arguments, t.name)

--- a/plip/plipcmd
+++ b/plip/plipcmd
@@ -10,7 +10,6 @@ from __future__ import absolute_import
 
 # Own modules
 from modules.preparation import *
-from modules.visualize import visualize_in_pymol
 from modules.plipremote import VisualizerData
 from modules.report import StructureReport,__version__
 from modules import config
@@ -73,6 +72,7 @@ def process_pdb(pdbfile, outpath, as_string=False):
     ######################################
 
     if config.PYMOL or config.PICS:
+        from modules.visualize import visualize_in_pymol
         complexes = [VisualizerData(mol, site) for site in sorted(mol.interaction_sets)
                      if not len(mol.interaction_sets[site].interacting_res) == 0]
         if config.MAXTHREADS > 1:


### PR DESCRIPTION
At the moment we cannot run the following command without pymol:   
```
$ plip -i 4HVD -x
Traceback (most recent call last):
  File "./plipcmd", line 12, in <module>
    from modules.preparation import *
  File "/home/xrobin/src/plip/modules/preparation.py", line 13, in <module>
    from .detection import *
  File "/home/xrobin/src/plip/modules/detection.py", line 12, in <module>
    from .supplemental import *
  File "/home/xrobin/src/plip/modules/supplemental.py", line 30, in <module>
    from pymol import cmd
ImportError: No module named pymol
```
However PyMOL is required for visualization only, and isn't required to generate the XML report for instance. This is a problem on our cluster as PyMOL is quite difficult to install with all its dependencies, and the sysadmins aren't keen to deploy it on all the nodes of the cluster.

This pull request makes the PyMOL dependency optional by re-organizing the imports, so that `import pymol` is triggered only when required (ie. with `--pymol` and `--pics`). The above command now runs also without pymol.