### PR TITLE
Expose more identifiers in BSite

### DIFF
--- a/plip/modules/plipxml.py
+++ b/plip/modules/plipxml.py
@@ -195,6 +195,8 @@ class BSite(XMLStorage):
         self.ligtype = self.getdata(bindingsite, 'identifiers/ligtype')
         self.smiles = self.getdata(bindingsite, 'identifiers/smiles')
         self.inchikey = self.getdata(bindingsite, 'identifiers/inchikey')
+        self.position = self.getdata(bindingsite, 'identifiers/position')
+        self.chain = self.getdata(bindingsite, 'identifiers/chain')
 
         # Information on binding site members
         self.members = []


### PR DESCRIPTION
In order to map the report from PLIP to the ligands submitted as input model, I need to access the `identifiers/position` and `identifiers/chain` nodes within each `bindingsite`. 
This commit does exactly that.