### PR TITLE
Let the client handle IOErrors in PLIPXML constructors

### DIFF
--- a/plip/modules/plipxml.py
+++ b/plip/modules/plipxml.py
@@ -289,11 +289,7 @@ class PLIPXML(XMLStorage):
 
     def load_data(self, xmlfile):
         """Loads/parses an XML file and saves it as a tree if successful."""
-        try:
-            self.doc = etree.parse(xmlfile)
-        except IOError:
-            sys.__stderr__.write("XML %s file could not be read." % xmlfile)
-            sys.exit(1)
+        self.doc = etree.parse(xmlfile)
 
 class PLIPXMLREST(PLIPXML):
     """Parses and stores all from a PLIP XML file from the PLIP REST service"""
@@ -304,8 +300,4 @@ class PLIPXMLREST(PLIPXML):
         """Loads and parses an XML resource and saves it as a tree if successful"""
         #TODO Implement error handling
         f = urlopen("http://projects.biotec.tu-dresden.de/plip-rest/pdb/%s?format=xml" % pdbid.lower())
-        try:
-            self.doc = etree.parse(f)
-        except IOError:
-            sys.__stderr__.write("XML file for PDB ID %s could not be read." % pdbid)
-            sys.exit(1)
+        self.doc = etree.parse(f)


### PR DESCRIPTION
It would be nice to be able to handle IOErrors myself when loading files with `plip.plipxml.PLIPXML`. _Throw early, Catch late._

The current behavior of the PLIPXML constructor is to catch the IO error, print an error message and issue a `sys.exit()`. This stops the server abruptly.

This effectively prevents me from doing anything with this error, such as run `plipcmd` to generate the report, or display a "No data available" message to the user. In addition I cannot imaging what would happen on the production server.

This pull request simply strips the try-except logic from the library in order to let the client handle this case. Depending on your local usage this may need some rewriting of the code outside of the PLIP module.