### PR TITLE
Excluded ligands not captured in PLIPXML

### DIFF
--- a/plip/modules/plipxml.py
+++ b/plip/modules/plipxml.py
@@ -282,7 +282,7 @@ class PLIPXML(XMLStorage):
         self.filetype = self.getdata(self.doc, '/report/filetype')
         self.fixed = self.getdata(self.doc, '/report/pdbfixes/')
         self.filename = self.getdata(self.doc, '/report/filename')
-        self.excluded = self.getdata(self.doc, '/report/excluded_ligands')
+        self.excluded = self.doc.xpath('/report/excluded_ligands/excluded_ligand/text()')
 
         # Parse binding site information
         self.bsites = {BSite(bs, self.pdbid).bsid: BSite(bs, self.pdbid) for bs in self.doc.xpath('//bindingsite')}


### PR DESCRIPTION
PLIPXML.excluded contains only garbage whitepace character when excluded_ligands is present in the report.xml. See attachement:

```
(venv_plip) zohixe92@worker02:~/plip/excluded_ligands$ python
Python 2.7.11 (default, Jan  6 2017, 12:05:36)
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from plip.modules.plipxml import PLIPXML
>>> report = PLIPXML('report.xml')
>>> report.excluded
'\n    '
```
Now the same code gives the correct result:
```
(venv_plip) zohixe92@worker02:~/plip/excluded_ligands$ python
Python 2.7.11 (default, Jan  6 2017, 12:05:36)
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from plip.modules.plipxml import PLIPXML
>>> report = PLIPXML('report.xml')
>>> report.excluded
['SR']
```


[report.xml.gz](https://github.com/ssalentin/plip/files/2102541/report.xml.gz)

