### PR TITLE
add support for importing from openbabel 3.0.x

### DIFF
--- a/plip/modules/detection.py
+++ b/plip/modules/detection.py
@@ -11,7 +11,10 @@ import numpy as np
 from collections import namedtuple
 
 # External Libraries
-from openbabel import OBAtomAtomIter
+try:  # for openbabel < 3.0.0
+    from openbabel import OBAtomAtomIter
+except ImportError: # for openbabel >= 3.0.0
+    from openbabel.openbabel import OBAtomAtomIter
 
 # Own modules
 from .supplemental import whichresnumber, whichrestype, whichchain, write_message

--- a/plip/modules/preparation.py
+++ b/plip/modules/preparation.py
@@ -25,7 +25,10 @@ from .supplemental import read, nucleotide_linkage, sort_members_by_importance
 from . import config
 
 # External modules
-import pybel
+try: # for openbabel < 3.0.0
+    import pybel
+except ImportError: # for openbabel >= 3.0.0
+    from openbabel import pybel
 
 
 ################

--- a/plip/modules/supplemental.py
+++ b/plip/modules/supplemental.py
@@ -11,8 +11,12 @@ from __future__ import absolute_import
 
 # External Libraries
 import numpy as np
-import pybel
-from pybel import Atom
+try: # for openbabel < 3.0.0
+    import pybel
+    from pybel import Atom
+except ImportError: # for openbabel >= 3.0.0
+    from openbabel import pybel
+    from openbabel.pybel import Atom
 
 # PLIP Modules
 from . import config


### PR DESCRIPTION
Modified the `imort` part of **detection.py**, **preparation.py** and **supplemental.py** so now it could import pybel and openbabel modules properly with Openbabel 3.0.x .  